### PR TITLE
Mitigate flicker on the default omega move icon

### DIFF
--- a/src/scripts/JowdayDPS.Main.lua
+++ b/src/scripts/JowdayDPS.Main.lua
@@ -450,7 +450,7 @@ function getSourceName(triggerArgs, victim)
     -- print('final source before lookup: ' .. source)
 
     source = NameLookup[source] or source
-    
+
     -- charm has several flavors
     local isCharmed = attackerTable.Charmed or activeEffects["Charm"] == 1 or activeEffectsStart["Charm"] == 1
     if isCharmed then

--- a/src/scripts/JowdayDPS.Main.lua
+++ b/src/scripts/JowdayDPS.Main.lua
@@ -191,10 +191,13 @@ function calculateDps(list)
 
     -- Delete any existing UI (e.g the bars from last update)
     -- TODO: Consider resizing / renaming bars instead of destroying and recreating (no performance issues so far though)
+
+    local barsToDelete = {}
     for bar, component in pairs(DpsBars) do
-        game.Destroy({ Id = component.Id })
+        table.insert(barsToDelete, component.Id)
         DpsBars[bar] = nil
     end
+    game.thread(game.DestroyOnDelay, barsToDelete, 0.005)
 
     for bar, component in pairs(DpsIcons) do
         game.Destroy({ Id = component.Id })
@@ -447,7 +450,7 @@ function getSourceName(triggerArgs, victim)
     -- print('final source before lookup: ' .. source)
 
     source = NameLookup[source] or source
-
+    
     -- charm has several flavors
     local isCharmed = attackerTable.Charmed or activeEffects["Charm"] == 1 or activeEffectsStart["Charm"] == 1
     if isCharmed then


### PR DESCRIPTION
Very slightly delay the deletion on dps bars to make sure the omega symbol doesn't disappear momentarily. I have tested this in a full run and didn't notice any obvious issues with this.

Before.

https://github.com/user-attachments/assets/b5f82a5a-12af-4bdf-b08e-3f8a504eb9ff

After

https://github.com/user-attachments/assets/52ba5215-6bfc-4a28-9c3c-f55a4b3087da

