### PR TITLE
Fix separate instances of Breaker Rush showing up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- fix separate instances of Breaker Rush showing up
+
 ## [2.9.9] - 2026-01-18
 
 ## Fixed

--- a/src/scripts/JowdayDPS.Data.lua
+++ b/src/scripts/JowdayDPS.Data.lua
@@ -169,6 +169,7 @@ function getLocalizedNames()
         DemeterSprintStorm = "Dash",
         HephSprintBlast = "Dash",
         PoseidonSprintBlast = "Dash",
+        PoseidonSprintSecondaryBlast = "Dash",
         ZeusSprintStrike = "Dash",
         PoseidonCastSplashSplinter = "WeaponCast",
         AphroditeCastProjectile = "WeaponCast",
@@ -321,7 +322,6 @@ function getLocalizedNames()
             ["PoseidonOmegaProjectile"] = posOCast,
             ["PoseidonEffectFont"] = "KnockbackAmplify",
             ["PoseidonOmegaWave"] = "OmegaPoseidonProjectileBoon",
-            ["PoseidonSprintSecondaryBlast"] = "PoseidonSprintBoon"
         },
         Selene = {
             ["WeaponSpellLaser"] = "SpellLaserTrait",


### PR DESCRIPTION
Similar to the recent Total Eclipse fix https://github.com/The-Black-Lodge/JowdayDamageMeter/pull/39

Before
<img width="2560" height="1440" alt="Hades II_762" src="https://github.com/user-attachments/assets/80d6674a-a796-46ce-8f5f-6337b9a62fbb" />

After
<img width="2560" height="1440" alt="Hades II_760" src="https://github.com/user-attachments/assets/e5f41794-a4c3-4e18-ad2a-110c9e3a7d9d" />
