### PR TITLE
Add proper logging for Winter Harvest kills and fix Shocking Loss logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Properly log insta kill effects, Shocking Loss and Winter Harvest
+
 ## [2.9.11] - 2026-04-04
 
 ## Updated

--- a/src/scripts/JowdayDPS.Main.lua
+++ b/src/scripts/JowdayDPS.Main.lua
@@ -893,6 +893,7 @@ ModUtil.Path.Wrap("DamageEnemy", function(baseFunc, victim, triggerArgs)
     --print(TableToJSONString(triggerArgs))
     --print(CurrentRun.Hero.ObjectId)
     local preHitHealth = victim.Health
+    local preHitHealthBuffer = victim.HealthBuffer or 0
     baseFunc(victim, triggerArgs)
     local attackerTable = triggerArgs.AttackerTable or {}
     local activeEffects = attackerTable.ActiveEffects or {}
@@ -937,6 +938,19 @@ ModUtil.Path.Wrap("DamageEnemy", function(baseFunc, victim, triggerArgs)
         return
     end
 
+    -- Shocking Loss, need special case as triggerArgs doesn't have AttackerName for this projectile
+    -- We also calculate exact damage dealt through shields and don't allow raw damage to always be 9999
+    if triggerArgs.SourceProjectile == "ZeusOnSpawn" then
+        -- on really high scaled enemies in Dream Dives, health can reach above 9999 and 
+        -- the insta-kill stops working but it still ends up dealing 9999 damage
+        local isInstaKill = preHitHealth <= triggerArgs.DamageAmount
+        local healthDamage = math.min(preHitHealth, triggerArgs.DamageAmount)
+        -- since shields are ignored by ZeusOnSpawn, count them in damage dealt
+        local healthBufferDamage = (isInstaKill and preHitHealthBuffer) or 0 
+        logDamage("ZeusOnSpawn", preHitHealth + preHitHealthBuffer, healthDamage + healthBufferDamage)
+        return
+    end
+
     local source = getSourceName(triggerArgs, victim)
 
     -- properly display Hitch damage
@@ -976,6 +990,18 @@ ModUtil.Path.Wrap("DamageEnemy", function(baseFunc, victim, triggerArgs)
 
     end
 end, mod)
+
+-- this needs its own wrap as it never calls DamageEnemy and directly kills the victim instead
+-- check if FiredChillKill has been updated and attribute remaining victim health to Winter Harvest
+ModUtil.Path.Wrap("CheckChillKill", function (baseFunc, args, attacker, victim, triggerArgs)
+    local preCheckKillHealth = victim.Health
+    local firedChillKillCache = game.SessionMapState.FiredChillKill[victim.ObjectId]
+    baseFunc(args, attacker, victim, triggerArgs)
+    if not firedChillKillCache and game.SessionMapState.FiredChillKill[victim.ObjectId] then
+        -- print("logging chill kill for", victim.Name, preCheckKillHealth)
+        logDamage("DemeterChillKill", preCheckKillHealth, preCheckKillHealth)
+    end
+end)
 
 --[[ on room unlock:
     - stop polling


### PR DESCRIPTION
Set enemy health to 12000 to test this. Winter Harvest now properly gets logged at around 8%. Shocking Loss gets logged at 9999 plus some adds it killed with 100 health.

<img width="2560" height="1440" alt="Hades II_1814" src="https://github.com/user-attachments/assets/b6e2c2bd-c760-4dcf-877f-74f5aef59fd6" />
